### PR TITLE
Paper cuts

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -24,8 +24,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
 
       - name: Prepare Git User
         run: |

--- a/README.md
+++ b/README.md
@@ -131,6 +131,21 @@ $validated // True or False
 > It is advisable not to let the user know if the OTP does not match, or does not exist or expired. 
 > You can return a generic message to the user instead.
 
+### Invalidating a Token
+
+It is highly recommended to invalid OTPs to avoid abuse. You can call `invalidate()` on the Otp object which deletes it from the database.
+
+```php
+use NjoguAmos\Otp\Otp;
+
+$otp = Otp::generate(identifier: 'example@gmail.com');
+
+$otp->invalidate();
+```
+
+> [!NOTE]
+> Please note that validating a token automatically invalidates it to avoid secondary use
+
 ### Delete Expired OTPs
 
 To periodically delete expired OTPs, you can use the `model:prune` Artisan command. This command will delete all expired OTPs from the database.

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,7 @@
         "pestphp/pest-plugin-laravel": "^v3.1",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan-deprecation-rules": "^2.0",
-        "phpstan/phpstan-phpunit": "^2.0",
-        "spatie/pest-plugin-test-time": "^2.1"
+        "phpstan/phpstan-phpunit": "^2.0"
     },
     "autoload": {
         "psr-4": {
@@ -76,7 +75,7 @@
                 "NjoguAmos\\Otp\\OtpServiceProvider"
             ],
             "aliases": {
-                "Otp": "NjoguAmos\\Otp\\OtpFacade"
+                "Otp": "NjoguAmos\\Otp\\Otp"
             }
         }
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5e8976dfcb2ac921c4cb6be420f4c3e0",
+    "content-hash": "0f206641da2920d1964cad6aea34fdf4",
     "packages": [
         {
             "name": "brick/math",
@@ -1056,16 +1056,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v12.8.1",
+            "version": "v12.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "d1ea3566f6e0cad34834c6d18db0bf995438eb87"
+                "reference": "0f123cc857bc177abe4d417448d4f7164f71802a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/d1ea3566f6e0cad34834c6d18db0bf995438eb87",
-                "reference": "d1ea3566f6e0cad34834c6d18db0bf995438eb87",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/0f123cc857bc177abe4d417448d4f7164f71802a",
+                "reference": "0f123cc857bc177abe4d417448d4f7164f71802a",
                 "shasum": ""
             },
             "require": {
@@ -1174,7 +1174,7 @@
                 "league/flysystem-sftp-v3": "^3.25.1",
                 "mockery/mockery": "^1.6.10",
                 "orchestra/testbench-core": "^10.0.0",
-                "pda/pheanstalk": "^5.0.6",
+                "pda/pheanstalk": "^5.0.6|^7.0.0",
                 "php-http/discovery": "^1.15",
                 "phpstan/phpstan": "^2.0",
                 "phpunit/phpunit": "^10.5.35|^11.5.3|^12.0.1",
@@ -1267,7 +1267,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-04-08T19:58:59+00:00"
+            "time": "2025-04-24T14:11:20+00:00"
         },
         {
             "name": "laravel/prompts",
@@ -1391,16 +1391,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.6.1",
+            "version": "2.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "d990688c91cedfb69753ffc2512727ec646df2ad"
+                "reference": "06c3b0bf2540338094575612f4a1778d0d2d5e94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/d990688c91cedfb69753ffc2512727ec646df2ad",
-                "reference": "d990688c91cedfb69753ffc2512727ec646df2ad",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/06c3b0bf2540338094575612f4a1778d0d2d5e94",
+                "reference": "06c3b0bf2540338094575612f4a1778d0d2d5e94",
                 "shasum": ""
             },
             "require": {
@@ -1494,7 +1494,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-29T14:10:59+00:00"
+            "time": "2025-04-18T21:09:27+00:00"
         },
         {
             "name": "league/config",
@@ -6216,16 +6216,16 @@
         },
         {
             "name": "larastan/larastan",
-            "version": "v3.3.1",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/larastan/larastan.git",
-                "reference": "58bee8be51daf12d78ed0a909be3b205607d2f27"
+                "reference": "1042fa0c2ee490bb6da7381f3323f7292ad68222"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/larastan/larastan/zipball/58bee8be51daf12d78ed0a909be3b205607d2f27",
-                "reference": "58bee8be51daf12d78ed0a909be3b205607d2f27",
+                "url": "https://api.github.com/repos/larastan/larastan/zipball/1042fa0c2ee490bb6da7381f3323f7292ad68222",
+                "reference": "1042fa0c2ee490bb6da7381f3323f7292ad68222",
                 "shasum": ""
             },
             "require": {
@@ -6242,7 +6242,7 @@
                 "phpstan/phpstan": "^2.1.11"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^12.0",
+                "doctrine/coding-standard": "^13",
                 "laravel/framework": "^11.44.2 || ^12.7.2",
                 "mockery/mockery": "^1.6.12",
                 "nikic/php-parser": "^5.4",
@@ -6278,13 +6278,9 @@
                 {
                     "name": "Can Vural",
                     "email": "can9119@gmail.com"
-                },
-                {
-                    "name": "Nuno Maduro",
-                    "email": "enunomaduro@gmail.com"
                 }
             ],
-            "description": "Larastan - Discover bugs in your code without running it. A phpstan/phpstan wrapper for Laravel",
+            "description": "Larastan - Discover bugs in your code without running it. A phpstan/phpstan extension for Laravel",
             "keywords": [
                 "PHPStan",
                 "code analyse",
@@ -6297,19 +6293,15 @@
             ],
             "support": {
                 "issues": "https://github.com/larastan/larastan/issues",
-                "source": "https://github.com/larastan/larastan/tree/v3.3.1"
+                "source": "https://github.com/larastan/larastan/tree/v3.4.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/canvural",
                     "type": "github"
-                },
-                {
-                    "url": "https://github.com/nunomaduro",
-                    "type": "github"
                 }
             ],
-            "time": "2025-04-03T20:08:04+00:00"
+            "time": "2025-04-22T09:44:59+00:00"
         },
         {
             "name": "laravel/pail",
@@ -6962,16 +6954,16 @@
         },
         {
             "name": "orchestra/sidekick",
-            "version": "v1.1.1",
+            "version": "v1.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/sidekick.git",
-                "reference": "ebdf88caa31735f7d00f289f070d4e9772774174"
+                "reference": "bc47409229e55a9a2861fd55f77d7d79ffa09b05"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/sidekick/zipball/ebdf88caa31735f7d00f289f070d4e9772774174",
-                "reference": "ebdf88caa31735f7d00f289f070d4e9772774174",
+                "url": "https://api.github.com/repos/orchestral/sidekick/zipball/bc47409229e55a9a2861fd55f77d7d79ffa09b05",
+                "reference": "bc47409229e55a9a2861fd55f77d7d79ffa09b05",
                 "shasum": ""
             },
             "require": {
@@ -6982,7 +6974,7 @@
             "require-dev": {
                 "laravel/framework": "^9.52.16|^10.48.29|^11.44.1|^12.1.1|^13.0",
                 "laravel/pint": "^1.4",
-                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan": "^2.1.12",
                 "phpunit/phpunit": "^9.6|^10.0|^11.0|^12.0",
                 "symfony/process": "^6.0|^7.0"
             },
@@ -7010,9 +7002,9 @@
             "description": "Packages Toolkit Utilities and Helpers for Laravel",
             "support": {
                 "issues": "https://github.com/orchestral/sidekick/issues",
-                "source": "https://github.com/orchestral/sidekick/tree/v1.1.1"
+                "source": "https://github.com/orchestral/sidekick/tree/v1.1.5"
             },
-            "time": "2025-04-05T16:44:56+00:00"
+            "time": "2025-04-25T03:48:23+00:00"
         },
         {
             "name": "orchestra/testbench",
@@ -7071,21 +7063,21 @@
         },
         {
             "name": "orchestra/testbench-core",
-            "version": "v10.2.1",
+            "version": "v10.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench-core.git",
-                "reference": "87f7e0e08e601756a444d7ac48027656ebeacf01"
+                "reference": "beed0fa81c3bb37b67e348d0963a33c5f1933fe5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/87f7e0e08e601756a444d7ac48027656ebeacf01",
-                "reference": "87f7e0e08e601756a444d7ac48027656ebeacf01",
+                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/beed0fa81c3bb37b67e348d0963a33c5f1933fe5",
+                "reference": "beed0fa81c3bb37b67e348d0963a33c5f1933fe5",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.2",
-                "orchestra/sidekick": "^1.1.0",
+                "orchestra/sidekick": "^1.1.5",
                 "php": "^8.2",
                 "symfony/deprecation-contracts": "^2.5|^3.0",
                 "symfony/polyfill-php83": "^1.31"
@@ -7100,12 +7092,12 @@
             "require-dev": {
                 "fakerphp/faker": "^1.24",
                 "laravel/framework": "^12.1.1",
-                "laravel/pint": "^1.21",
+                "laravel/pint": "^1.22",
                 "laravel/serializable-closure": "^1.3|^2.0.4",
                 "mockery/mockery": "^1.6.10",
-                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan": "^2.1.12",
                 "phpunit/phpunit": "^10.5.35|^11.5.3|^12.0.1",
-                "spatie/laravel-ray": "^1.39.1",
+                "spatie/laravel-ray": "^1.40.2",
                 "symfony/process": "^7.2.0",
                 "symfony/yaml": "^7.2.0",
                 "vlucas/phpdotenv": "^5.6.1"
@@ -7160,7 +7152,7 @@
                 "issues": "https://github.com/orchestral/testbench/issues",
                 "source": "https://github.com/orchestral/testbench-core"
             },
-            "time": "2025-04-13T01:12:52+00:00"
+            "time": "2025-04-27T05:36:02+00:00"
         },
         {
             "name": "orchestra/workbench",
@@ -7484,27 +7476,27 @@
         },
         {
             "name": "pestphp/pest-plugin-laravel",
-            "version": "v3.1.0",
+            "version": "v3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest-plugin-laravel.git",
-                "reference": "1c4e994476375c72aa7aebaaa97aa98f5d5378cd"
+                "reference": "6801be82fd92b96e82dd72e563e5674b1ce365fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest-plugin-laravel/zipball/1c4e994476375c72aa7aebaaa97aa98f5d5378cd",
-                "reference": "1c4e994476375c72aa7aebaaa97aa98f5d5378cd",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-laravel/zipball/6801be82fd92b96e82dd72e563e5674b1ce365fc",
+                "reference": "6801be82fd92b96e82dd72e563e5674b1ce365fc",
                 "shasum": ""
             },
             "require": {
-                "laravel/framework": "^11.39.1|^12.0.0",
-                "pestphp/pest": "^3.7.4",
+                "laravel/framework": "^11.39.1|^12.9.2",
+                "pestphp/pest": "^3.8.2",
                 "php": "^8.2.0"
             },
             "require-dev": {
                 "laravel/dusk": "^8.2.13|dev-develop",
-                "orchestra/testbench": "^9.9.0|^10.0.0",
-                "pestphp/pest-dev-tools": "^3.3.0"
+                "orchestra/testbench": "^9.9.0|^10.2.1",
+                "pestphp/pest-dev-tools": "^3.4.0"
             },
             "type": "library",
             "extra": {
@@ -7542,7 +7534,7 @@
                 "unit"
             ],
             "support": {
-                "source": "https://github.com/pestphp/pest-plugin-laravel/tree/v3.1.0"
+                "source": "https://github.com/pestphp/pest-plugin-laravel/tree/v3.2.0"
             },
             "funding": [
                 {
@@ -7554,7 +7546,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-24T13:22:39+00:00"
+            "time": "2025-04-21T07:40:53+00:00"
         },
         {
             "name": "pestphp/pest-plugin-mutate",
@@ -8018,16 +8010,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.11",
+            "version": "2.1.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "8ca5f79a8f63c49b2359065832a654e1ec70ac30"
+                "reference": "e55e03e6d4ac49cd1240907e5b08e5cd378572a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8ca5f79a8f63c49b2359065832a654e1ec70ac30",
-                "reference": "8ca5f79a8f63c49b2359065832a654e1ec70ac30",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e55e03e6d4ac49cd1240907e5b08e5cd378572a9",
+                "reference": "e55e03e6d4ac49cd1240907e5b08e5cd378572a9",
                 "shasum": ""
             },
             "require": {
@@ -8072,25 +8064,25 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-24T13:45:00+00:00"
+            "time": "2025-04-27T12:28:25+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-deprecation-rules.git",
-                "reference": "1cc1259cb91ee4cfbb5c39bca9f635f067c910b4"
+                "reference": "9d8e7d4e32711715ad78a1fb6ec368df9af01fdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/1cc1259cb91ee4cfbb5c39bca9f635f067c910b4",
-                "reference": "1cc1259cb91ee4cfbb5c39bca9f635f067c910b4",
+                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/9d8e7d4e32711715ad78a1fb6ec368df9af01fdf",
+                "reference": "9d8e7d4e32711715ad78a1fb6ec368df9af01fdf",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0",
-                "phpstan/phpstan": "^2.0"
+                "phpstan/phpstan": "^2.1.13"
             },
             "require-dev": {
                 "php-parallel-lint/php-parallel-lint": "^1.2",
@@ -8117,9 +8109,9 @@
             "description": "PHPStan rules for detecting usage of deprecated classes, methods, properties, constants and traits.",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-deprecation-rules/issues",
-                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/2.0.1"
+                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/2.0.2"
             },
-            "time": "2024-11-28T21:56:36+00:00"
+            "time": "2025-04-26T19:59:57+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -9604,138 +9596,6 @@
             "time": "2024-10-09T05:16:32+00:00"
         },
         {
-            "name": "spatie/pest-plugin-test-time",
-            "version": "2.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/spatie/pest-plugin-test-time.git",
-                "reference": "82af5b73a7f140a2cbfbe2926ef14dd35ee169be"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/spatie/pest-plugin-test-time/zipball/82af5b73a7f140a2cbfbe2926ef14dd35ee169be",
-                "reference": "82af5b73a7f140a2cbfbe2926ef14dd35ee169be",
-                "shasum": ""
-            },
-            "require": {
-                "nesbot/carbon": "^2.65|^3",
-                "pestphp/pest": "^2.0|^3.0",
-                "php": "^8.1",
-                "spatie/test-time": "^1.3.2"
-            },
-            "require-dev": {
-                "spatie/ray": "^1.36"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-v2": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/Functions.php"
-                ],
-                "psr-4": {
-                    "Spatie\\PestPluginTestTime\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Freek Van der Herten",
-                    "email": "freek@spatie.be",
-                    "role": "Developer"
-                }
-            ],
-            "description": "A Pest plugin to  control the flow of time",
-            "homepage": "https://github.com/spatie/pest-plugin-test-time",
-            "keywords": [
-                "pest-plugin-test-time",
-                "spatie"
-            ],
-            "support": {
-                "source": "https://github.com/spatie/pest-plugin-test-time/tree/2.2.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/spatie",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-09-20T13:40:22+00:00"
-        },
-        {
-            "name": "spatie/test-time",
-            "version": "1.3.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/spatie/test-time.git",
-                "reference": "308242a6c7ce4af2455ee0ab61b7d3d627cb78fd"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/spatie/test-time/zipball/308242a6c7ce4af2455ee0ab61b7d3d627cb78fd",
-                "reference": "308242a6c7ce4af2455ee0ab61b7d3d627cb78fd",
-                "shasum": ""
-            },
-            "require": {
-                "nesbot/carbon": "^2.63|^3.0",
-                "php": "^7.3|^8.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.5.10"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Spatie\\TestTime\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Freek Van der Herten",
-                    "email": "freek@spatie.be",
-                    "homepage": "https://spatie.be",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Alex Vanderbist",
-                    "email": "alex@spatie.be",
-                    "homepage": "https://spatie.be",
-                    "role": "Developer"
-                }
-            ],
-            "description": "A small package to control the flow time",
-            "homepage": "https://github.com/spatie/test-time",
-            "keywords": [
-                "spatie",
-                "test-time"
-            ],
-            "support": {
-                "issues": "https://github.com/spatie/test-time/issues",
-                "source": "https://github.com/spatie/test-time/tree/1.3.3"
-            },
-            "funding": [
-                {
-                    "url": "https://spatie.be/open-source/support-us",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/spatie",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-02-05T13:30:14+00:00"
-        },
-        {
             "name": "staabm/side-effects-detector",
             "version": "1.0.5",
             "source": {
@@ -9971,12 +9831,12 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.3"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/src/GenerateOtp.php
+++ b/src/GenerateOtp.php
@@ -39,12 +39,17 @@ final readonly class GenerateOtp
 
     public function validate(string $identifier, string $token): bool
     {
-        return OtpModel::active()
+        $model = OtpModel::active()
             ->where(column: 'identifier', operator: '=', value: $identifier)
-            ->get('token')
-            ->contains(
+            ->get(['token', 'id'])
+            ->first(
                 fn (OtpModel $otp) => $otp->token === $token
             );
+
+        return (bool) tap(
+            value: $model?->exists() === true,
+            callback: fn () => $model?->invalidate()
+        );
     }
 
     private function createRandomToken(): string

--- a/src/GenerateOtp.php
+++ b/src/GenerateOtp.php
@@ -27,7 +27,7 @@ final readonly class GenerateOtp
     {
         Validator::validate(
             ['identifier' => $identifier],
-            ['identifier' => ['required', 'string', 'max:255']],
+            ['identifier' => ['required', 'max:255']],
         );
 
         return OtpModel::create([

--- a/src/Models/Otp.php
+++ b/src/Models/Otp.php
@@ -22,7 +22,10 @@ class Otp extends Model
         'channel',
     ];
 
-
+    public function invalidate(): void
+    {
+        $this->delete();
+    }
     protected function casts(): array
     {
         return [

--- a/src/Otp.php
+++ b/src/Otp.php
@@ -10,6 +10,6 @@ class Otp extends Facade
 {
     protected static function getFacadeAccessor(): string
     {
-        return 'generate-otp';
+        return GenerateOtp::class;
     }
 }

--- a/src/OtpServiceProvider.php
+++ b/src/OtpServiceProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace NjoguAmos\Otp;
 
-use Illuminate\Config\Repository;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 

--- a/src/OtpServiceProvider.php
+++ b/src/OtpServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NjoguAmos\Otp;
 
+use Illuminate\Config\Repository;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -19,24 +20,13 @@ class OtpServiceProvider extends PackageServiceProvider
 
     public function registeringPackage(): void
     {
-        $this->app->alias(abstract: GenerateOtp::class, alias: 'generate-otp');
-
-        $this->app->bind(abstract: GenerateOtp::class, concrete: function ($app) {
-            $config = $app['config']->get('otp');
-
-            if ($config['length'] < 4) {
-                throw InvalidArgumentException::create('The length of the OTP must be at least 4');
-            }
-
-            if ($config['validity'] < 1) {
-                throw InvalidArgumentException::create('The validity of the OTP must be at least 1 minute.');
-            }
-
-            return new GenerateOtp(
-                length: $config['length'],
-                validity: $config['validity'],
-                digits_only: $config['digits_only']
-            );
-        });
+        $this->app->bind(
+            abstract: GenerateOtp::class,
+            concrete: fn ($app) => new GenerateOtp(
+                length: config()->integer('otp.length'),
+                validity: config()->integer('otp.validity'),
+                digits_only: config()->boolean('otp.digits_only'),
+            )
+        );
     }
 }

--- a/tests/GenerateOtpTest.php
+++ b/tests/GenerateOtpTest.php
@@ -80,7 +80,7 @@ describe(description: 'validate otp', tests: function () {
     });
 
     it(description: 'cannot validate a token that does not exist', closure: function () {
-        $validated = Otp::validate(identifier: fake()->safeEmail, token: random_int(min: 1000, max: 9999));
+        $validated = Otp::validate(identifier: fake()->safeEmail, token: (string) random_int(min: 1000, max: 9999));
 
         expect(value: $validated)->toBeFalse();
     });
@@ -95,11 +95,12 @@ describe(description: 'exception', tests: function () {
         Otp::generate(identifier: 'example@gmail.com');
     })->throws(exception: InvalidArgumentException::class);
 
-    it(description: 'throws an exception if the identifier is greater than 255', closure: function () {
-        config()->set(key: 'otp.length', value: 6);
-
-        Otp::generate(identifier: str_repeat('long', 64).'@gmail.com');
-    })->throws(ValidationException::class);
+    it(description: 'throws an exception if the identifier is too short or too long', closure: function (string $identifier) {
+        Otp::generate(identifier: $identifier);
+    })->with([
+        str_repeat('too-long', 32).'@gmail.com',
+        '', // Too short
+    ])->throws(ValidationException::class);
 
     it(description: 'throws an exception if validity is less than 1', closure: function () {
         config()->set(key: 'otp.validity', value: 0);

--- a/tests/GenerateOtpTest.php
+++ b/tests/GenerateOtpTest.php
@@ -55,6 +55,14 @@ describe(description: 'validate otp', tests: function () {
         expect(value: $validated)->toBeTrue();
     });
 
+    it(description: 'invalidates token upon first use', closure: function () {
+        $otp = OtpModel::factory()->create();
+
+        Otp::validate(identifier: $otp->identifier, token: $otp->token);
+
+        expect(value: $otp->fresh())->toBeNull();
+    });
+
     it(description: 'cannot validate with invalid token', closure: function () {
         $email = fake()->safeEmail();
 

--- a/tests/OtpModelTest.php
+++ b/tests/OtpModelTest.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Facades\DB;
 use NjoguAmos\Otp\Models\Otp as OtpModel;
 
 use function Pest\Laravel\artisan;
-use function Spatie\PestPluginTestTime\testTime;
 
 it(description: 'encrypts token when saving to database', closure: function () {
     $otp = OtpModel::factory()->create(attributes: ['token' => 123456]);
@@ -41,7 +40,7 @@ it(description: 'can can scope by active otps', closure: function () {
 });
 
 it(description: 'can get expires in attribute', closure: function () {
-    testTime()->freeze();
+    $this->freezeTime();
 
     $otp = OtpModel::factory()->create(['expires_at' => now()->addMinutes(5)->addSeconds(10)]);
 

--- a/tests/OtpModelTest.php
+++ b/tests/OtpModelTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\DB;
 use NjoguAmos\Otp\Models\Otp as OtpModel;
 
 use function Pest\Laravel\artisan;
+use function Pest\Laravel\assertDatabaseMissing;
 
 it(description: 'encrypts token when saving to database', closure: function () {
     $otp = OtpModel::factory()->create(attributes: ['token' => 123456]);
@@ -45,4 +46,14 @@ it(description: 'can get expires in attribute', closure: function () {
     $otp = OtpModel::factory()->create(['expires_at' => now()->addMinutes(5)->addSeconds(10)]);
 
     expect(value: $otp->expires_in)->toBe(expected: '5 minutes');
+});
+
+it(description: 'deletes invalidated tokens', closure: function () {
+    $otp = OtpModel::factory()->create();
+
+    $otp->invalidate();
+
+    expect(value: $otp->fresh())->toBeNull();
+
+    assertDatabaseMissing(table: 'otps', data: ['id' => $otp->getKey()]);
 });


### PR DESCRIPTION
This PR introduces a few paper-cuts:

- Validating a token immediately invalidates it to prevent the token from being used twice: One Time is in the name after all 😜
- Switches from `spatie/pest-plugin-test-time` package to Laravel's inbuilt freezing time during tests
- Use the FQDN for the Facade accessor: This allows IDEs to add features such auto-completion and click-through.
- Moved `GenerateOtp` validation to the class: less magic 🪄 and single responsibility.
- among others