### PR TITLE
Fix styling workflow

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -27,21 +27,5 @@ jobs:
 
       - name: Fix PHP code style issues
         uses: aglipanci/laravel-pint-action@2.5
-
-      - name: Create Fixer PR
-        run: |
-          if [[ -z $(git status --porcelain) ]]; then
-           echo "Nothing to fix.. Exiting."
-           exit 0
-          fi
-          OPEN_PRS=`curl --silent -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/$GITHUB_REPOSITORY/pulls?state=open"`
-          OPEN_FIXER_PRS=`echo ${OPEN_PRS} | grep -o "\"ref\": \"${{ env.FIXER_BRANCH }}\"" | wc -l`
-          git commit -am "${{ env.TITLE }}"
-          git push origin "${{ env.FIXER_BRANCH }}" --force
-          if [ ${OPEN_FIXER_PRS} -eq "0" ]; then
-           curl -X POST \
-           -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-              "https://api.github.com/repos/$GITHUB_REPOSITORY/pulls" \
-              -d "{ \"head\":\"${{ env.FIXER_BRANCH }}\", \"base\":\"${{ env.SOURCE_BRANCH }}\", \"title\":\"${{ env.TITLE }}\", \"body\":\"${{ env.DESCRIPTION }}\n\nTriggered by #${{ env.PR_NUMBER }}\" }"
-          fi
+        with:
+          testMode: true

--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -24,14 +24,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
-
-      - name: Prepare Git User
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -B "${{ env.FIXER_BRANCH }}"
 
       - name: Fix PHP code style issues
         uses: aglipanci/laravel-pint-action@2.5

--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -5,21 +5,12 @@ on:
     paths:
       - '**.php'
 
-env:
-  PR_NUMBER: '${{ github.event.number }}'
-  SOURCE_BRANCH: '$GITHUB_HEAD_REF'
-  FIXER_BRANCH: 'auto-fixed/$GITHUB_HEAD_REF'
-  TITLE: 'Format PHP code'
-  DESCRIPTION: 'This merge request applies code style fixes from an analysis carried out through GitHub Actions.'
-
 permissions:
   contents: write
 
 jobs:
   php-code-styling:
-    if: github.event_name == 'pull_request' && ! startsWith(github.ref, 'refs/heads/auto-fixed/')
     runs-on: ubuntu-latest
-    timeout-minutes: 5
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
The action `actions/checkout` with the option `github.head_ref` does not work on forks as the ref does exists on a different repo. If this option is not passed, the action is intelligent enough to checkout the right repository and ref.

The second change updates pint to run in testMode. This fails the CI run so that code style issues can be fixed locally. This avoids unnecessary code conflicts and allows you to review all changes locally before pushing to Github.