### PR TITLE
Delete token after use

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,22 @@ $validated // True or False
 > It is advisable not to let the user know if the OTP does not match, or does not exist or expired. 
 > You can return a generic message to the user instead.
 
+
+### Invalidating a Token
+
+It is highly recommended to invalid OTPs to avoid abuse. You can call `invalidate()` on the Otp object which deletes it from the database.
+
+```php
+use NjoguAmos\Otp\Otp;
+
+$otp = Otp::generate(identifier: 'example@gmail.com');
+
+$otp->invalidate();
+```
+
+> [!NOTE]
+> Please note that validating a token automatically invalidates it to avoid second time use
+
 ### Delete Expired OTPs
 
 To periodically delete expired OTPs, you can use the `model:prune` Artisan command. This command will delete all expired OTPs from the database.

--- a/src/GenerateOtp.php
+++ b/src/GenerateOtp.php
@@ -43,6 +43,7 @@ final readonly class GenerateOtp
             ->where(column: 'identifier', operator: '=', value: $identifier)
             ->get(['token', 'id'])
             ->first(
+                /** @phpstan-ignore-next-line */
                 fn (OtpModel $otp) => $otp->token === $token
             );
 

--- a/src/GenerateOtp.php
+++ b/src/GenerateOtp.php
@@ -39,11 +39,17 @@ final readonly class GenerateOtp
 
     public function validate(string $identifier, string $token): bool
     {
-        $opts = OtpModel::active()
+        $model = OtpModel::active()
             ->where(column: 'identifier', operator: '=', value: $identifier)
-            ->get()->pluck('token')->all();
+            ->get(['token', 'id'])
+            ->first(
+                fn (OtpModel $otp) => $otp->token === $token
+            );
 
-        return in_array($token, $opts);
+        return (bool) tap(
+            value: $model?->exists() === true,
+            callback: fn () => $model?->invalidate()
+        );
     }
 
     private function createRandomToken(): string

--- a/src/Models/Otp.php
+++ b/src/Models/Otp.php
@@ -57,4 +57,9 @@ class Otp extends Model
     {
         return static::where('expires_at', '<', now());
     }
+
+    public function invalidate(): void
+    {
+        $this->delete();
+    }
 }

--- a/src/Models/Otp.php
+++ b/src/Models/Otp.php
@@ -22,7 +22,6 @@ class Otp extends Model
         'channel',
     ];
 
-
     protected function casts(): array
     {
         return [

--- a/tests/GenerateOtpTest.php
+++ b/tests/GenerateOtpTest.php
@@ -53,6 +53,14 @@ describe(description: 'validate otp', tests: function () {
         expect(value: $validated)->toBeTrue();
     });
 
+    it(description: 'invalidates token upon first use', closure: function () {
+        $otp = OtpModel::factory()->create();
+
+        Otp::validate(identifier: $otp->identifier, token: $otp->token);
+
+        expect(value: $otp->fresh())->toBeNull();
+    });
+
     it(description: 'cannot validate with invalid token', closure: function () {
         $email = fake()->safeEmail();
 

--- a/tests/OtpModelTest.php
+++ b/tests/OtpModelTest.php
@@ -46,3 +46,11 @@ it(description: 'can get expires in attribute', closure: function () {
 
     expect(value: $otp->expires_in)->toBe(expected: '5 minutes');
 });
+
+it(description: 'deletes invalidated tokens', closure: function () {
+    $otp = OtpModel::factory()->create();
+
+    $otp->invalidate();
+
+    expect(value: $otp->fresh())->toBeNull();
+});


### PR DESCRIPTION
Delete OTP tokens after validating.

This prevents the same from being reused which would be a security risk depending on the use.

One Time is in the name after-all 🤷🏻‍♂️